### PR TITLE
Make some policy parameters optional

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -33,11 +33,19 @@
 # policy (key is id as in Foreman)
 {% for policy in foreman_scap_client_policies %}
 {{ policy['id'] }}:
+{% if 'profile_id' in policy %}
   :profile: {{ policy['profile_id'] }}
+{% endif %}
   :content_path: {{ policy['content_path']}}
   # Download path
   # A path to download SCAP content from proxy
+{% if 'download_path' in policy %}
   :download_path: {{ policy['download_path'] }}
+{% endif %}
+{% if 'tailoring_path' in policy %}
   :tailoring_path: {{ policy['tailoring_path'] }}
+{% endif %}
+{% if 'tailoring_download_path' in policy %}
   :tailoring_download_path: {{ policy['tailoring_download_path'] }}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
The scap client doesn't really need a lot of the parameters that are included in the template, however it will fail if they are left blank.
This way if a parameter is not specified in the ansible variables the line will just not be added to the configuration file.