### PR TITLE
Remove .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
----
-sudo: required
-language: python
-services:
-  - docker
-before_install:
-  - sudo apt-get -qq update
-script:
-  - molecule test


### PR DESCRIPTION
ansible-lint currently passes even though there are failures. We could probably move to the ansible-lint gh action to see if that makes the step fail.