### PR TITLE
Add support for other OS (Debian/Ubuntu/Suse)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,11 @@ jobs:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
           MOLECULE_DISTRO: ${{ matrix.distro }}
+
+      - name: Run Molecule tests on ubuntu-scenario.
+        run: molecule test -s ubuntu
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        distro: [centos7, centos8, ubuntu2004]
         include:
           - distro: centos7
+            command: molecule test
           - distro: centos8
+            command: molecule test
+          - distro: ubuntu2004
+            command: molecule test -s ubuntu
 
     steps:
       - name: Check out the codebase.
@@ -60,16 +65,10 @@ jobs:
         run: pip3 install -r requirements.txt
 
       - name: Run Molecule tests.
-        run: molecule test
+        run: ${{ matrix.command }}
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
           MOLECULE_DISTRO: ${{ matrix.distro }}
 
-      - name: Run Molecule tests on ubuntu-scenario.
-        run: molecule test -s ubuntu
-        env:
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
-          MOLECULE_DISTRO: ${{ matrix.distro }}
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ of foreman_scap_client and create a cron which schedules the client execution.
 ### Variables
 
 * 'foreman_scap_client_state': state of the rubygem-foreman_scap_client package
+* 'foreman_scap_client_package': name of the package if it differs from the default (rubygem-foreman_scap_client for el7/suse or ruby-foreman-scap-client for debian/ubuntu)
 * 'foreman_scap_client_server': configures the proxy server
 * 'foreman_scap_client_port': configures the proxy server's port
 * 'foreman_scap_client_policies': Array of policies that should be configured
@@ -20,6 +21,7 @@ of foreman_scap_client and create a cron which schedules the client execution.
 * 'foreman_scap_client_host_private_key_path': path to host private key, may be puppet agent private key or katello private key
 * 'foreman_scap_client_release': Which release to configure a repo for
 * 'foreman_scap_client_repo_url': URL for the repository with rubygem-foreman_scap_client
+* 'foreman_scap_client_apt_repo_url: Debian-based repository providing the scap-client & subscription-manager
 * 'foreman_scap_client_repo_state': state of the repository
 * 'foreman_scap_client_repo_key': RPM Key source file for foreman-plugins repo. Note: Currently, packages are not signed.
   Unless set to an alternative file source, URL will be used.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 foreman_scap_client_state: present
+foreman_scap_client_package: ''
 foreman_scap_client_server: ''
 foreman_scap_client_port: 9090
 foreman_scap_client_policies: []
@@ -8,6 +9,7 @@ foreman_scap_client_host_cert_path: ''
 foreman_scap_client_host_private_key_path: ''
 foreman_scap_client_release: latest
 foreman_scap_client_repo_url: 'https://yum.theforeman.org/client/{{ foreman_scap_client_release }}/el7/x86_64'
+foreman_scap_client_apt_repo_url: 'deb [trusted=yes] https://apt.atix.de/Ubuntu20LTS/ stable main'
 foreman_scap_client_repo_state: absent
 foreman_scap_client_repo_key: 'https://yum.theforeman.org/RPM-GPG-KEY-foreman'
 foreman_scap_client_repo_gpg: false

--- a/molecule/ubuntu/converge.yml
+++ b/molecule/ubuntu/converge.yml
@@ -1,0 +1,42 @@
+---
+- name: Converge
+  hosts: all
+  pre_tasks:
+    - name: 'Install cron'
+      package:
+        name: systemd-cron
+        state: present
+    - name: 'Add subscription-manager-repo for apt'
+      apt_repository:
+        repo: 'deb [trusted=yes] https://apt.atix.de/Ubuntu20LTS/ stable main'
+        state: present
+    - name: 'Install subscription-manager'
+      package:
+        name: subscription-manager
+        state: present
+  roles:
+    - role: theforeman.foreman_scap_client
+  vars:
+    foreman_scap_client_repo_state: present
+    foreman_scap_client_server: https://foreman.example.com
+    foreman_scap_client_port: 9090
+    foreman_scap_client_cron_splay_seed: 42
+    foreman_scap_client_http_proxy_server: 'https://proxy.example.com'
+    foreman_scap_client_http_proxy_port: 7475
+    foreman_scap_client_fetch_remote_resources: true
+    foreman_scap_client_timeout: 61
+    foreman_scap_client_policies: [
+      {
+        "id": "1",
+        "hour": "12",
+        "minute": "1",
+        "month": "*",
+        "monthday": "*",
+        "weekday": "1",
+        "profile_id": "",
+        "content_path": "/usr/share/xml/scap/ssg/fedora/ssg-fedora-ds.xml",
+        "download_path": "/compliance/policies/1/content",
+        "tailoring_path": "/var/lib/openscap/ssg-fedora-ds-tailored.xml",
+        "tailoring_download_path": "/compliance/policies/1/tailoring"
+      }
+    ]

--- a/molecule/ubuntu/molecule.yml
+++ b/molecule/ubuntu/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: ubuntu20
+    image: geerlingguy/docker-ubuntu2004-ansible:latest
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+scenario:
+  name: ubuntu
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/ubuntu/tests/test_default.py
+++ b/molecule/ubuntu/tests/test_default.py
@@ -1,0 +1,59 @@
+import os
+import yaml
+import re
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_foreman_scap_client_package(host):
+    assert host.package('ruby-foreman-scap-client').is_installed
+
+def test_foreman_scap_client_config(host):
+    file_path = '/etc/foreman_scap_client/config.yaml'
+    file = host.file(file_path)
+
+    assert file.exists
+    assert file.contains(':fetch_remote_resources: true')
+
+    config = yaml.safe_load(file.content_string)
+
+    assert config[":port"] == 9090
+    assert config[":server"] == 'https://foreman.example.com'
+    assert config[":timeout"] == 61
+
+    assert config[':http_proxy_server'] == 'https://proxy.example.com'
+    assert config[':http_proxy_port'] == 7475
+    assert (config[1][":profile"] is None)
+
+    assert (config[1][":content_path"] ==
+            "/usr/share/xml/scap/ssg/fedora/ssg-fedora-ds.xml")
+    assert (config[1][":download_path"] ==
+            "/compliance/policies/1/content")
+    assert (config[1][":tailoring_path"] ==
+            "/var/lib/openscap/ssg-fedora-ds-tailored.xml")
+    assert (config[1][":tailoring_download_path"] ==
+            "/compliance/policies/1/tailoring")
+    assert config[':ca_file'] == '/etc/rhsm/ca/redhat-uep.pem'
+    assert config[':host_certificate'] == '/etc/pki/consumer/cert.pem'
+    assert config[':host_private_key'] == '/etc/pki/consumer/key.pem'
+
+
+def test_foreman_scap_client_cron(host):
+    file_path = '/etc/cron.d/foreman_scap_client_cron'
+    file = host.file(file_path)
+
+    assert file.exists
+
+    cron = file.content_string
+
+    n = -1
+    if cron.split('\n')[n] == '':
+        n = -2
+
+    assert re.match(
+        r'1 12 \* \* 1 root /bin/sleep \d+; /usr/bin/foreman_scap_client 1 2>&1 | logger -t foreman_scap_client',
+        cron.split('\n')[n]
+    )

--- a/molecule/ubuntu/yaml-lint.yml
+++ b/molecule/ubuntu/yaml-lint.yml
@@ -1,0 +1,6 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 120
+    level: warning

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Configure plugins repository
+- name: Configure plugins repository (yum)
   yum_repository:
     name: "foreman-plugins-{{ foreman_scap_client_release }}"
     description: "Foreman plugins repository"
@@ -7,10 +7,31 @@
     gpgcheck: "{{ foreman_scap_client_repo_gpg }}"
     gpgkey: "{{ foreman_scap_client_repo_key }}"
     state: "{{ foreman_scap_client_repo_state }}"
+  when: ansible_os_family == "RedHat"
+
+- name: Configure plugins repository (apt)
+  apt_repository:
+    repo: "{{ foreman_scap_client_apt_repo_url }}"
+    state: "{{ foreman_scap_client_repo_state }}"
+  when: ansible_os_family == "Debian"
+
+- name: Set facts for deb-based OS
+  set_fact:
+    package_name: >
+      {{ (foreman_scap_client_package | length > 0)
+      | ternary(foreman_scap_client_package,'ruby-foreman-scap-client') }}
+  when: ansible_os_family == "Debian"
+
+- name: Set facts for rpm-based OS
+  set_fact:
+    package_name: >
+      {{ (foreman_scap_client_package | length > 0)
+      | ternary(foreman_scap_client_package,'rubygem-foreman_scap_client') }}
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 
 - name: Install the foreman_scap_client package
-  yum:
-    name: "rubygem-foreman_scap_client"
+  package:
+    name: "{{ package_name }}"
     state: "{{ foreman_scap_client_state }}"
 
 - name: Get certificate paths


### PR DESCRIPTION
Compared to the puppet-module, which already runs on Suse/Debian/Ubuntu the current version of the ansible-role only works with yum (CentOS/RHEL 7).

With minor changes it is possible to extend this to these other OSes - see Pull Request
To provide also a test I added a second molecule scenario with Ubuntu20.04 because I did not want to change the current tests.
To get it running on Ubuntu20.04 you can use the ATIX-repositories including the scap-client as well as the subscription-manager.

Furthermore I tested it on my infrastructure with SLES 15 SP2, Debian10, CentOS 7 and Ubuntu 20.04 - however without automatic tests.