### PR TITLE
Update supported OS in meta/main.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [centos7, centos8, ubuntu2004]
+        distro: [centos7, centos8, ubuntu2004, debian10]
         include:
           - distro: centos7
             command: molecule test
@@ -49,6 +49,8 @@ jobs:
             command: molecule test
           - distro: ubuntu2004
             command: molecule test -s ubuntu
+          - distro: debian10
+            command: molecule test -s debian
 
     steps:
       - name: Check out the codebase.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,13 +18,9 @@ galaxy_info:
     - name: Debian
       versions:
         - 10
-    - name: SLES
-      versions:
-        - 15
   galaxy_tags:
     - rhel
     - centos
     - ubuntu
     - debian
-    - sles
     - openscap

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,19 @@ galaxy_info:
       versions:
         - 6
         - 7
+    - name: Ubuntu
+      versions:
+        - 20.04
+    - name: Debian
+      versions:
+        - 10
+    - name: SLES
+      versions:
+        - 15
   galaxy_tags:
     - rhel
     - centos
+    - ubuntu
+    - debian
+    - sles
     - openscap

--- a/molecule/debian/converge.yml
+++ b/molecule/debian/converge.yml
@@ -1,0 +1,42 @@
+---
+- name: Converge
+  hosts: all
+  pre_tasks:
+    - name: 'Install cron'
+      package:
+        name: systemd-cron
+        state: present
+    - name: 'Add subscription-manager-repo for apt'
+      apt_repository:
+        repo: 'deb [trusted=yes] https://apt.atix.de/Debian10/ stable main'
+        state: present
+    - name: 'Install subscription-manager'
+      package:
+        name: subscription-manager
+        state: present
+  roles:
+    - role: theforeman.foreman_scap_client
+  vars:
+    foreman_scap_client_repo_state: present
+    foreman_scap_client_server: https://foreman.example.com
+    foreman_scap_client_port: 9090
+    foreman_scap_client_cron_splay_seed: 42
+    foreman_scap_client_http_proxy_server: 'https://proxy.example.com'
+    foreman_scap_client_http_proxy_port: 7475
+    foreman_scap_client_fetch_remote_resources: true
+    foreman_scap_client_timeout: 61
+    foreman_scap_client_policies: [
+      {
+        "id": "1",
+        "hour": "12",
+        "minute": "1",
+        "month": "*",
+        "monthday": "*",
+        "weekday": "1",
+        "profile_id": "",
+        "content_path": "/usr/share/xml/scap/ssg/fedora/ssg-fedora-ds.xml",
+        "download_path": "/compliance/policies/1/content",
+        "tailoring_path": "/var/lib/openscap/ssg-fedora-ds-tailored.xml",
+        "tailoring_download_path": "/compliance/policies/1/tailoring"
+      }
+    ]

--- a/molecule/debian/molecule.yml
+++ b/molecule/debian/molecule.yml
@@ -4,8 +4,8 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: instance
-    image: geerlingguy/docker-ubuntu2004-ansible:latest
+  - name: instance 
+    image: geerlingguy/docker-debian10-ansible:latest
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -14,7 +14,7 @@ platforms:
 provisioner:
   name: ansible
 scenario:
-  name: ubuntu
+  name: debian 
 verifier:
   name: testinfra
   lint:

--- a/molecule/debian/tests/test_default.py
+++ b/molecule/debian/tests/test_default.py
@@ -1,0 +1,59 @@
+import os
+import yaml
+import re
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_foreman_scap_client_package(host):
+    assert host.package('ruby-foreman-scap-client').is_installed
+
+def test_foreman_scap_client_config(host):
+    file_path = '/etc/foreman_scap_client/config.yaml'
+    file = host.file(file_path)
+
+    assert file.exists
+    assert file.contains(':fetch_remote_resources: true')
+
+    config = yaml.safe_load(file.content_string)
+
+    assert config[":port"] == 9090
+    assert config[":server"] == 'https://foreman.example.com'
+    assert config[":timeout"] == 61
+
+    assert config[':http_proxy_server'] == 'https://proxy.example.com'
+    assert config[':http_proxy_port'] == 7475
+    assert (config[1][":profile"] is None)
+
+    assert (config[1][":content_path"] ==
+            "/usr/share/xml/scap/ssg/fedora/ssg-fedora-ds.xml")
+    assert (config[1][":download_path"] ==
+            "/compliance/policies/1/content")
+    assert (config[1][":tailoring_path"] ==
+            "/var/lib/openscap/ssg-fedora-ds-tailored.xml")
+    assert (config[1][":tailoring_download_path"] ==
+            "/compliance/policies/1/tailoring")
+    assert config[':ca_file'] == '/etc/rhsm/ca/redhat-uep.pem'
+    assert config[':host_certificate'] == '/etc/pki/consumer/cert.pem'
+    assert config[':host_private_key'] == '/etc/pki/consumer/key.pem'
+
+
+def test_foreman_scap_client_cron(host):
+    file_path = '/etc/cron.d/foreman_scap_client_cron'
+    file = host.file(file_path)
+
+    assert file.exists
+
+    cron = file.content_string
+
+    n = -1
+    if cron.split('\n')[n] == '':
+        n = -2
+
+    assert re.match(
+        r'1 12 \* \* 1 root /bin/sleep \d+; /usr/bin/foreman_scap_client 1 2>&1 | logger -t foreman_scap_client',
+        cron.split('\n')[n]
+    )

--- a/molecule/debian/yaml-lint.yml
+++ b/molecule/debian/yaml-lint.yml
@@ -1,0 +1,6 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 120
+    level: warning


### PR DESCRIPTION
Hi,
as previously mentioned in https://github.com/theforeman/ansible-foreman_scap_client/pull/31#issuecomment-796595636 I wanted to update the meta/main.yml with the supported OS.

I did not only add Ubuntu 20.04, but also SLES 15 and Debian 10, as I have tested them. However, I only added a test for Ubuntu 20.04. 
I could add the test for Debian 10 as well (should be the same as for Ubuntu with different repo and different image) - but for SLES 15 I do not have a public available repository with the subscription-manager and the scap-client - as well as geerlingguys docker images do not offer a SLES-container.

If you prefer I can also remove the SLES from the meta-information.