### PR TITLE
Only render templates when needed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,7 @@
     owner: root
     group: root
     mode: '0644'
+  when: "foreman_scap_client_state != 'absent'"
 
 - name: Ensure cron and config are {{ foreman_scap_client_state }}
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,7 @@
     owner: root
     group: root
     mode: '0644'
+  when: "foreman_scap_client_state != 'absent'"
 
 - name: Create config.yaml in /etc/foreman_scap_client
   template:


### PR DESCRIPTION
Only render `templates/config.yaml.j2` when `foreman_scap_client_state != 'absent'` as the task will fail in case that
`foreman_scap_client_state == 'absent'`. In case that `foreman_scap_client_state == 'absent'` the `foreman_scap_client_package` will not be installed and hence the directory `/etc/foreman_scap_client` does not exist. This causes the rendering task to fail.

Only render `foreman_scap_client_cron_template` when `foreman_scap_client_state != 'absent'` as the role is not idempotent in case that `foreman_scap_client_state == 'absent'`. In case that `foreman_scap_client_state == 'absent'` the task will create
`/etc/cron.d/foreman_scap_client_cron` and the 'Ensure cron and config are {{ foreman_scap_client_state }}' task will remove
it afterwards which makes the role not idempotent.

