### PR TITLE
Add check for OpenSCAP proxy

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Ensure that the host has an OpenSCAP proxy assigned.
+  ansible.builtin.assert:
+    that: foreman_scap_client_server != ''
+    fail_msg: "The host does not have an OpenSCAP proxy assigned. Please assign an OpenSCAP proxy before continuing."
+    success_msg: "The assigned OpenSCAP proxy is {{ foreman_scap_client_server }}."
+
 - name: Configure plugins repository (yum)
   yum_repository:
     name: "foreman-plugins-{{ foreman_scap_client_release }}"


### PR DESCRIPTION
Currently, when the host or host group does not have OpenSCAP proxy assigned, the role can finish without an error. However; subsequent OpenSCAP scans on the host fail. This PR resolves this by adding a check which causes the role to fail is no OpenSCAP proxy is selected.